### PR TITLE
Register initialization

### DIFF
--- a/display.py
+++ b/display.py
@@ -4,12 +4,25 @@ import serial
 
 ser = serial.Serial("COM6", 6000000)
 
+correction = np.array([[1.36, -0.3, -0.06], 
+                        [-0.20, 1.32, -0.12], 
+                        [-0.04, -0.55, 1.59]])
+
 while (True):
     data = ser.read_until(b"FRAME")
     data = ser.read(153600)
+    print(len(data))
+
+    # buf = np.frombuffer(data, dtype=np.uint8)
+    # s = 153600 // 2
+    # print(buf[s:s+8])
+    # print(buf[s+8:s+16])
+    # print(U.min(), U.max(), V.min(), V.max())
+
     img = cv2.cvtColor(
-        np.frombuffer(data, dtype=np.uint8).reshape(240, 320, 2), cv2.COLOR_YUV2BGR_UYVY 
-    )[:,:,[2,0,1]]
+        np.frombuffer(data, dtype=np.uint8).reshape(240, 320, 2), cv2.COLOR_YUV2RGB_UYVY 
+    )
+    img = img @ correction.T
 
     cv2.imwrite("output/test.png", img)
     print("WRITE")

--- a/teensy4.0-OV7670-3D_Camera.ino
+++ b/teensy4.0-OV7670-3D_Camera.ino
@@ -101,7 +101,6 @@ void getPicture() {
       while (digitalReadFast(PCLK) == HIGH); // wait until clock ticks to LOW to continue 
 
     }
-    while (digitalReadFast(HS) == HIGH);
   }
   interrupts();
 
@@ -117,7 +116,7 @@ void configureCamera() {
 
   // decrease pclk
   uint8_t clkrc_byte = readFromRegister(CLKRC);
-  if (!writeToRegister(CLKRC, (clkrc_byte | 0b00000000))) {
+  if (!writeToRegister(CLKRC, (clkrc_byte | 0b00000001))) {
     return;
   }
 

--- a/teensy4.0-OV7670-3D_Camera.ino
+++ b/teensy4.0-OV7670-3D_Camera.ino
@@ -13,6 +13,7 @@
 #define REG_VER 0x0b  // Product ID LSB
 
 #define COM7 0x12 // Common control 7 output format option
+#define COM13 0x3D // Common control 13 Gamme, UV saturation, UV swap
 #define COM15 0x40 // Common control 15 RGB 555/565 option
 #define MVFP 0x1E // Scan direction control
 #define SCALING_XSC 0x70
@@ -49,22 +50,18 @@ void setup() {
 
   Wire.begin();
   Serial.begin(6000000);
-  Serial.println("########################################");
-
-  test_i2c_read();
-
-  configureCamera();
-
-  // setTestPattern();
 
   // set data pins as inputs
   for (int pin : DATA_PINS) {
     pinMode(pin, INPUT);
   }
   pinMode(HS, INPUT);
-
   pinMode(VS, INPUT);
   pinMode(PCLK, INPUT);
+
+  // test_i2c_read();
+  configureCamera();
+  // setTestPattern();
 }
 
 void loop() {
@@ -145,6 +142,239 @@ void configureCamera() {
   if (!writeToRegister(MVFP, (0b00110000))) {
     return;
   }
+
+  // writeToRegister(0x4f, 0x80);
+  // writeToRegister(0x50, 0x80);
+  // writeToRegister(0x51, 0x00);
+  // writeToRegister(0x52, 0x22);
+  // writeToRegister(0x53, 0x5e);
+  // writeToRegister(0x54, 0x80);
+
+  // uint8_t mtxsbyte = readFromRegister(0x58);
+  // if (!writeToRegister(0x58, (mtxsbyte | 0b00011010))) {
+  //   return;
+  // }
+
+  // uint8_t com13byte = readFromRegister(COM13);
+  // if (!writeToRegister(COM13, (com13byte | 0b11000000))) {
+  //   return;
+  // }
+
+  // setTestPattern();
+// writeToRegister(0x3A, 0x04);
+// writeToRegister(0x12, 0x00);
+
+writeToRegister(0x17, 0x13);  // HSTART- changing these flips color channels - probably has to do with, if 
+writeToRegister(0x18, 0x01);  // HSTOP - start/stop are off, we chop off bits and the alignment becomes wrong? 
+// Commenting these out seems to gives right RGB order and gets rid of weird borders on sides
+
+writeToRegister(0x32, 0xB6); // HREF - seems like can be left commented without issue
+
+writeToRegister(0x19, 0x02); // VSTRT - more output frame settings, seems can be commented but maybe images looked a bit better?
+writeToRegister(0x1A, 0x7A); // VSTOP - Try both these settings again later
+
+writeToRegister(0x03, 0x0A); // VREF - seems can be commented
+
+writeToRegister(0x0C, 0x00); // COM3 - this is default value in datasheet so can probably be commented
+writeToRegister(0x3E, 0x00); // COM14 - datasheet says to set this to 0x19; seems necessary
+writeToRegister(0x3E, 0x19); // COM14 - datasheet says to set this to 0x19; but setting to 0 seems necessary; seems
+                            // key part is setting bit 3 to 0, so that scaling cannot be adjusted manually
+
+writeToRegister(0x70, 0x3A);
+writeToRegister(0x71, 0x35);
+writeToRegister(0x72, 0x11); // SCALING_DCWCTR DCW Control - down sampling?
+writeToRegister(0x73, 0xF0); // SCALING_PCLK_DIV Clock scaling for DSP?
+writeToRegister(0xA2, 0x01); // SCALING_PCLK_DELAY Pixel Clock Delay, seems necessary
+writeToRegister(0x15, 0x00); // COM10, polarities and options for *SYNC, *REF, PCLK pins
+
+// GAMMA CURVE, seems important for good image but isn't necessary for good colors
+writeToRegister(0x7A, 0x20);
+writeToRegister(0x7B, 0x10);
+writeToRegister(0x7C, 0x1E);
+writeToRegister(0x7D, 0x35);
+writeToRegister(0x7E, 0x5A);
+writeToRegister(0x7F, 0x69);
+writeToRegister(0x80, 0x76);
+writeToRegister(0x81, 0x80);
+writeToRegister(0x82, 0x88);
+writeToRegister(0x83, 0x8F);
+writeToRegister(0x84, 0x96);
+writeToRegister(0x85, 0xA3);
+writeToRegister(0x86, 0xAF);
+writeToRegister(0x87, 0xC4);
+writeToRegister(0x88, 0xD7);
+writeToRegister(0x89, 0xE8);
+
+// writeToRegister(0x13, 0xC0); // COM8 AGC/AEC/AWB enables
+// writeToRegister(0x00, 0x00); // GAIN AGC Gain control gain setting
+writeToRegister(0x10, 0x00); // AECH Exposure Value
+writeToRegister(0x0D, 0x40); // COM4 average window option; this is default setting
+writeToRegister(0x14, 0x18); // COM9 Automatic Gain Ceiling
+writeToRegister(0xA5, 0x05); // AECGMAX Maximum Banding Filter Step
+writeToRegister(0xAB, 0x07); // RSVD RESERVED
+writeToRegister(0x24, 0x95); // AEW AGC AEC Stable Operating Region Upper
+writeToRegister(0x25, 0x33); // AEB AGC AEC Stable Operating Region Lower
+writeToRegister(0x26, 0xE3); // VPT AGC AEC Fast Mode Operating Region
+writeToRegister(0x9F, 0x78); // HRL High Reference Luminance
+writeToRegister(0xA0, 0x68); // LRL Low Reference Luminance
+writeToRegister(0xA1, 0x03); // DSPC3 DSP Control 3
+writeToRegister(0xA6, 0xD8); // LPH Lower Limit of Probability for HRL
+writeToRegister(0xA7, 0xD8); // UPL Upper Limit of Probability for LRL
+writeToRegister(0xA8, 0xF0); // TPL Probability Threshold for LRL to control AEC/AGC speed
+writeToRegister(0xA9, 0x90); // TPH  Probability Threshold for HRL to control AEC/AGC speed
+writeToRegister(0xAA, 0x94); // NALG AEC algorithm selection, reserved
+writeToRegister(0x13, 0xC5); // COM8 !! repeat AGC/AEC/AWB enables; probably disabling before changing settings and re-enabling
+writeToRegister(0x30, 0x00); // HSYST HSYNC Rising Edge Delay
+writeToRegister(0x31, 0x00); // HSYEN HSYNC Falling Edge Delay
+writeToRegister(0x0E, 0x61); // COM5 RESERVED
+writeToRegister(0x0F, 0x4B); // COM6 reset all timing when format changes; output of optical black row option
+writeToRegister(0x16, 0x02); // RSVD RESERVED
+//// writeToRegister(0x1E, 0x07);
+writeToRegister(0x21, 0x02); // ADCCTR1 RESERVED
+writeToRegister(0x22, 0x91); // ADCCTR2 RESERVED
+writeToRegister(0x29, 0x07); // RSVD RESERVED 
+writeToRegister(0x33, 0x0B); // CHLF Array Current Control RESERVED
+writeToRegister(0x35, 0x0B); // RSVD RESERVed
+writeToRegister(0x37, 0x1D); // ADC ADC Control RESERVED
+writeToRegister(0x38, 0x71); // ACOM ADC and Analog Common Mode Control RESERVED
+writeToRegister(0x39, 0x2A); // OFON ADC Offset Control RESERVED
+writeToRegister(0x3C, 0x78); // COM12 HREF option when VSYNC low or always
+writeToRegister(0x4D, 0x40); // DM_POS Dummy row position
+writeToRegister(0x4E, 0x20); // RSVD RESERVED
+writeToRegister(0x69, 0x00); // GFIX Fix Gain Control
+writeToRegister(0x74, 0x10); // REG74 digital gain control select and manual controll
+writeToRegister(0x8D, 0x4F); // RSVD RESERVED
+writeToRegister(0x8E, 0x00); // RSVD RESERVED
+writeToRegister(0x8F, 0x00); // RSVD RESERVED
+writeToRegister(0x90, 0x00); // RSVD RESERVED
+writeToRegister(0x91, 0x00); // RSVD RESERVED
+writeToRegister(0x96, 0x00); // RSVD RESERVED
+writeToRegister(0x9A, 0x00); // RSVD RESERVED
+writeToRegister(0xB0, 0x84); // RSVD RESERVED
+writeToRegister(0xB1, 0x0C); // ABLC1 ALBC enable/disable
+writeToRegister(0xB2, 0x0E); // RSVD RESERVED
+writeToRegister(0xB3, 0x82); // THL_ST ABLC Target
+writeToRegister(0xB8, 0x0A); // RSVD RESERVED
+
+// AWBC AWB Control
+writeToRegister(0x43, 0x0A);
+writeToRegister(0x44, 0xF0);
+writeToRegister(0x45, 0x34);
+writeToRegister(0x46, 0x58);
+writeToRegister(0x47, 0x28);
+writeToRegister(0x48, 0x3A);
+writeToRegister(0x59, 0x88);
+writeToRegister(0x5A, 0x88);
+writeToRegister(0x5B, 0x44);
+writeToRegister(0x5C, 0x67);
+writeToRegister(0x5D, 0x49);
+writeToRegister(0x5E, 0x0E);
+writeToRegister(0x6C, 0x0A);
+writeToRegister(0x6D, 0x55);
+writeToRegister(0x6E, 0x11);
+writeToRegister(0x6F, 0x9E);
+
+
+writeToRegister(0x6A, 0x40); // GGAIN G Channel AWB Gain
+writeToRegister(0x01, 0x40); // BLUE AWB Blue channel gain
+writeToRegister(0x02, 0x60); // RED AWN REd channel gain
+
+writeToRegister(0x13, 0xC7); // COM8 AGC/AEC/Banding/enable REPEAT
+
+// MTX Color Matrix Coefficients
+writeToRegister(0x4F, 0x80);
+writeToRegister(0x50, 0x80);
+writeToRegister(0x51, 0x00);
+writeToRegister(0x52, 0x22);
+writeToRegister(0x53, 0x5E);
+writeToRegister(0x54, 0x80);
+writeToRegister(0x58, 0x9E); // MTXS signs, auto contrast
+
+writeToRegister(0x41, 0x08); // COM16 double color matrix, AWB gain enable, denoise, edge enhancement
+writeToRegister(0x3F, 0x00); // EDGE Edge Enhancement Adjustment
+writeToRegister(0x75, 0x05); // REG75 Edge enhancement lower limit
+writeToRegister(0x76, 0xE1); // REG76 Edge enhancement higher limit, black/white pixel correction
+writeToRegister(0x4C, 0x00); // DNSTH De-noise Strength
+writeToRegister(0x77, 0x01); // REG77 Offset, de-noise range control
+//// writeToRegister(0x3D, 0x48);
+writeToRegister(0x4B, 0x09); // REG4B, RESERVED, UV average unable
+writeToRegister(0xC9, 0x60); // SATCTR Saturation Control
+writeToRegister(0x56, 0x40); // CONTRAS Contrast Control
+writeToRegister(0x34, 0x11); // ARBLM Array Reference Control
+writeToRegister(0x3B, 0x12); // COM11 Night mode, auto 50/60Hz, exposure timing
+writeToRegister(0xA4, 0x82); // NT_CTRL auto frame adjustment dummy row
+writeToRegister(0x96, 0x00); // RSVD RESERVED
+writeToRegister(0x97, 0x30); // RSVD RESERVED
+writeToRegister(0x98, 0x20); // RSVD RESERVED
+writeToRegister(0x99, 0x30); // RSVD RESERVED
+writeToRegister(0x9A, 0x84); // RSVD RESERVED
+writeToRegister(0x9B, 0x29); // RSVD RESERVED
+writeToRegister(0x9C, 0x03); // RSVD RESERVED
+writeToRegister(0x9D, 0x4C); // BD50ST 50 Hz Banding Filter Value 
+writeToRegister(0x9E, 0x3F); // BD60ST ^0 Hz Banding Filter Value
+writeToRegister(0x78, 0x04); // RSVD RESERVED
+writeToRegister(0x79, 0x01); // RSVD RESERVED
+writeToRegister(0xC8, 0xF0); // RSVD RESERVED
+writeToRegister(0x79, 0x0F); // RSVD RESERVED
+writeToRegister(0xC8, 0x00); // RSVD RESERVED
+writeToRegister(0x79, 0x10); // RSVD RESERVED
+writeToRegister(0xC8, 0x7E); // RSVD RESERVED
+writeToRegister(0x79, 0x0A); // RSVD RESERVED
+writeToRegister(0xC8, 0x80); // RSVD RESERVED
+writeToRegister(0x79, 0x0B); // RSVD RESERVED
+writeToRegister(0xC8, 0x01); // RSVD RESERVED
+writeToRegister(0x79, 0x0C); // RSVD RESERVED
+writeToRegister(0xC8, 0x0F); // RSVD RESERVED
+writeToRegister(0x79, 0x0D); // RSVD RESERVED
+writeToRegister(0xC8, 0x20); // RSVD RESERVED
+writeToRegister(0x79, 0x09); // RSVD RESERVED
+writeToRegister(0xC8, 0x80); // RSVD RESERVED
+writeToRegister(0x79, 0x02); // RSVD RESERVED
+writeToRegister(0xC8, 0xC0); // RSVD RESERVED
+writeToRegister(0x79, 0x03); // RSVD RESERVED
+writeToRegister(0xC8, 0x40); // RSVD RESERVED
+writeToRegister(0x79, 0x05); // RSVD RESERVED
+writeToRegister(0xC8, 0x30); // RSVD RESERVED
+writeToRegister(0x79, 0x26); // RSVD RESERVED
+writeToRegister(0xFF, 0xFF);
+
+writeToRegister(0x15, 0x20); // COM10 *REF, *SYNC, PCLK polarities and settings
+writeToRegister(0x0C, 0x04); // COM3 output data MSB LSB swap, tristate options, scsale/DCW enable
+writeToRegister(0x3E, 0x19); // COM14 DCW and scaling PCLK, manual scaling enable, PCLK divider
+writeToRegister(0x72, 0x11); // SCALING_DCWCTR DCW Control
+writeToRegister(0x73, 0xF1); // SCALING PCLK_DIV
+writeToRegister(0x17, 0x16); // HSTART
+writeToRegister(0x18, 0x04); // HSTOP
+writeToRegister(0x32, 0xA4); // HREF
+writeToRegister(0x19, 0x02); // VSTRT
+writeToRegister(0x1A, 0x7A); // VSTOP
+writeToRegister(0x03, 0x0A); // VREF
+writeToRegister(0xFF, 0xFF); 
+
+writeToRegister(0x12, 0x00); // COM7 output format - YUV?
+writeToRegister(0x8C, 0x00); // RSVD RESERVED
+writeToRegister(0x04, 0x00); // COM1 CCIR656, AEC low 2 LSB
+// writeToRegister(0x40, 0xC0); // COM15 data format output range, RGB555/565 option
+writeToRegister(0x14, 0x6A); // COM9 Automatic Gain Ceiling
+
+// MTX Matrix Coefficients
+writeToRegister(0x4F, 0x80);
+writeToRegister(0x50, 0x80);
+writeToRegister(0x51, 0x00);
+writeToRegister(0x52, 0x22);
+writeToRegister(0x53, 0x5E);
+writeToRegister(0x54, 0x80);
+
+//// writeToRegister(0x3D, 0x40); // COM13 Gamma enable, UV saturation auto adjustment, UV swap
+writeToRegister(0xFF, 0xFF);
+
+// writeToRegister(0x11, 0x1F);
+writeToRegister(0x0C, 0x08); // COM3 output data MSB/LSB swap, tri state options, scale/DCW enable
+writeToRegister(0x3E, 0x19); // COM14 DCW and scaling PCLK enable, manual scaling enable, PCLK divider
+writeToRegister(0x73, 0xF1); // SCALING_PCLK_DIV
+writeToRegister(0x12, 0x10); // COM7 SCCB register reset, output format
+
+delay(1000); // wait for registers to be set (because it is quite slow)
 }
 
 uint8_t readFromRegister(int reg) {

--- a/teensy4.0-OV7670-3D_Camera.ino
+++ b/teensy4.0-OV7670-3D_Camera.ino
@@ -168,220 +168,220 @@ void configureCamera() {
   // }
 
   // setTestPattern();
-// writeToRegister(0x3A, 0x04);
-// writeToRegister(0x12, 0x00);
+  // writeToRegister(0x3A, 0x04);
+  // writeToRegister(0x12, 0x00);
 
-writeToRegister(0x17, 0x13);  // HSTART- changing these flips color channels - probably has to do with, if 
-writeToRegister(0x18, 0x01);  // HSTOP - start/stop are off, we chop off bits and the alignment becomes wrong? 
-// Commenting these out seems to gives right RGB order and gets rid of weird borders on sides
+  writeToRegister(0x17, 0x13);  // HSTART- changing these flips color channels - probably has to do with, if 
+  writeToRegister(0x18, 0x01);  // HSTOP - start/stop are off, we chop off bits and the alignment becomes wrong? 
+  // Commenting these out seems to gives right RGB order and gets rid of weird borders on sides
 
-writeToRegister(0x32, 0xB6); // HREF - seems like can be left commented without issue
+  writeToRegister(0x32, 0xB6); // HREF - seems like can be left commented without issue
 
-writeToRegister(0x19, 0x02); // VSTRT - more output frame settings, seems can be commented but maybe images looked a bit better?
-writeToRegister(0x1A, 0x7A); // VSTOP - Try both these settings again later
+  writeToRegister(0x19, 0x02); // VSTRT - more output frame settings, seems can be commented but maybe images looked a bit better?
+  writeToRegister(0x1A, 0x7A); // VSTOP - Try both these settings again later
 
-writeToRegister(0x03, 0x0A); // VREF - seems can be commented
+  writeToRegister(0x03, 0x0A); // VREF - seems can be commented
 
-writeToRegister(0x0C, 0x00); // COM3 - this is default value in datasheet so can probably be commented
-writeToRegister(0x3E, 0x00); // COM14 - datasheet says to set this to 0x19; seems necessary
-writeToRegister(0x3E, 0x19); // COM14 - datasheet says to set this to 0x19; but setting to 0 seems necessary; seems
-                            // key part is setting bit 3 to 0, so that scaling cannot be adjusted manually
+  writeToRegister(0x0C, 0x00); // COM3 - this is default value in datasheet so can probably be commented
+  writeToRegister(0x3E, 0x00); // COM14 - datasheet says to set this to 0x19; seems necessary
+  writeToRegister(0x3E, 0x19); // COM14 - datasheet says to set this to 0x19; but setting to 0 seems necessary; seems
+                              // key part is setting bit 3 to 0, so that scaling cannot be adjusted manually
 
-writeToRegister(0x70, 0x3A);
-writeToRegister(0x71, 0x35);
-writeToRegister(0x72, 0x11); // SCALING_DCWCTR DCW Control - down sampling?
-writeToRegister(0x73, 0xF0); // SCALING_PCLK_DIV Clock scaling for DSP?
-writeToRegister(0xA2, 0x01); // SCALING_PCLK_DELAY Pixel Clock Delay, seems necessary
-writeToRegister(0x15, 0x00); // COM10, polarities and options for *SYNC, *REF, PCLK pins
+  writeToRegister(0x70, 0x3A);
+  writeToRegister(0x71, 0x35);
+  writeToRegister(0x72, 0x11); // SCALING_DCWCTR DCW Control - down sampling?
+  writeToRegister(0x73, 0xF0); // SCALING_PCLK_DIV Clock scaling for DSP?
+  writeToRegister(0xA2, 0x01); // SCALING_PCLK_DELAY Pixel Clock Delay, seems necessary
+  writeToRegister(0x15, 0x00); // COM10, polarities and options for *SYNC, *REF, PCLK pins
 
-// GAMMA CURVE, seems important for good image but isn't necessary for good colors
-writeToRegister(0x7A, 0x20);
-writeToRegister(0x7B, 0x10);
-writeToRegister(0x7C, 0x1E);
-writeToRegister(0x7D, 0x35);
-writeToRegister(0x7E, 0x5A);
-writeToRegister(0x7F, 0x69);
-writeToRegister(0x80, 0x76);
-writeToRegister(0x81, 0x80);
-writeToRegister(0x82, 0x88);
-writeToRegister(0x83, 0x8F);
-writeToRegister(0x84, 0x96);
-writeToRegister(0x85, 0xA3);
-writeToRegister(0x86, 0xAF);
-writeToRegister(0x87, 0xC4);
-writeToRegister(0x88, 0xD7);
-writeToRegister(0x89, 0xE8);
+  // GAMMA CURVE, seems important for good image but isn't necessary for good colors
+  writeToRegister(0x7A, 0x20);
+  writeToRegister(0x7B, 0x10);
+  writeToRegister(0x7C, 0x1E);
+  writeToRegister(0x7D, 0x35);
+  writeToRegister(0x7E, 0x5A);
+  writeToRegister(0x7F, 0x69);
+  writeToRegister(0x80, 0x76);
+  writeToRegister(0x81, 0x80);
+  writeToRegister(0x82, 0x88);
+  writeToRegister(0x83, 0x8F);
+  writeToRegister(0x84, 0x96);
+  writeToRegister(0x85, 0xA3);
+  writeToRegister(0x86, 0xAF);
+  writeToRegister(0x87, 0xC4);
+  writeToRegister(0x88, 0xD7);
+  writeToRegister(0x89, 0xE8);
 
-// writeToRegister(0x13, 0xC0); // COM8 AGC/AEC/AWB enables
-// writeToRegister(0x00, 0x00); // GAIN AGC Gain control gain setting
-writeToRegister(0x10, 0x00); // AECH Exposure Value
-writeToRegister(0x0D, 0x40); // COM4 average window option; this is default setting
-writeToRegister(0x14, 0x18); // COM9 Automatic Gain Ceiling
-writeToRegister(0xA5, 0x05); // AECGMAX Maximum Banding Filter Step
-writeToRegister(0xAB, 0x07); // RSVD RESERVED
-writeToRegister(0x24, 0x95); // AEW AGC AEC Stable Operating Region Upper
-writeToRegister(0x25, 0x33); // AEB AGC AEC Stable Operating Region Lower
-writeToRegister(0x26, 0xE3); // VPT AGC AEC Fast Mode Operating Region
-writeToRegister(0x9F, 0x78); // HRL High Reference Luminance
-writeToRegister(0xA0, 0x68); // LRL Low Reference Luminance
-writeToRegister(0xA1, 0x03); // DSPC3 DSP Control 3
-writeToRegister(0xA6, 0xD8); // LPH Lower Limit of Probability for HRL
-writeToRegister(0xA7, 0xD8); // UPL Upper Limit of Probability for LRL
-writeToRegister(0xA8, 0xF0); // TPL Probability Threshold for LRL to control AEC/AGC speed
-writeToRegister(0xA9, 0x90); // TPH  Probability Threshold for HRL to control AEC/AGC speed
-writeToRegister(0xAA, 0x94); // NALG AEC algorithm selection, reserved
-writeToRegister(0x13, 0xC5); // COM8 !! repeat AGC/AEC/AWB enables; probably disabling before changing settings and re-enabling
-writeToRegister(0x30, 0x00); // HSYST HSYNC Rising Edge Delay
-writeToRegister(0x31, 0x00); // HSYEN HSYNC Falling Edge Delay
-writeToRegister(0x0E, 0x61); // COM5 RESERVED
-writeToRegister(0x0F, 0x4B); // COM6 reset all timing when format changes; output of optical black row option
-writeToRegister(0x16, 0x02); // RSVD RESERVED
-//// writeToRegister(0x1E, 0x07);
-writeToRegister(0x21, 0x02); // ADCCTR1 RESERVED
-writeToRegister(0x22, 0x91); // ADCCTR2 RESERVED
-writeToRegister(0x29, 0x07); // RSVD RESERVED 
-writeToRegister(0x33, 0x0B); // CHLF Array Current Control RESERVED
-writeToRegister(0x35, 0x0B); // RSVD RESERVed
-writeToRegister(0x37, 0x1D); // ADC ADC Control RESERVED
-writeToRegister(0x38, 0x71); // ACOM ADC and Analog Common Mode Control RESERVED
-writeToRegister(0x39, 0x2A); // OFON ADC Offset Control RESERVED
-writeToRegister(0x3C, 0x78); // COM12 HREF option when VSYNC low or always
-writeToRegister(0x4D, 0x40); // DM_POS Dummy row position
-writeToRegister(0x4E, 0x20); // RSVD RESERVED
-writeToRegister(0x69, 0x00); // GFIX Fix Gain Control
-writeToRegister(0x74, 0x10); // REG74 digital gain control select and manual controll
-writeToRegister(0x8D, 0x4F); // RSVD RESERVED
-writeToRegister(0x8E, 0x00); // RSVD RESERVED
-writeToRegister(0x8F, 0x00); // RSVD RESERVED
-writeToRegister(0x90, 0x00); // RSVD RESERVED
-writeToRegister(0x91, 0x00); // RSVD RESERVED
-writeToRegister(0x96, 0x00); // RSVD RESERVED
-writeToRegister(0x9A, 0x00); // RSVD RESERVED
-writeToRegister(0xB0, 0x84); // RSVD RESERVED
-writeToRegister(0xB1, 0x0C); // ABLC1 ALBC enable/disable
-writeToRegister(0xB2, 0x0E); // RSVD RESERVED
-writeToRegister(0xB3, 0x82); // THL_ST ABLC Target
-writeToRegister(0xB8, 0x0A); // RSVD RESERVED
+  // writeToRegister(0x13, 0xC0); // COM8 AGC/AEC/AWB enables
+  // writeToRegister(0x00, 0x00); // GAIN AGC Gain control gain setting
+  writeToRegister(0x10, 0x00); // AECH Exposure Value
+  writeToRegister(0x0D, 0x40); // COM4 average window option; this is default setting
+  writeToRegister(0x14, 0x18); // COM9 Automatic Gain Ceiling
+  writeToRegister(0xA5, 0x05); // AECGMAX Maximum Banding Filter Step
+  writeToRegister(0xAB, 0x07); // RSVD RESERVED
+  writeToRegister(0x24, 0x95); // AEW AGC AEC Stable Operating Region Upper
+  writeToRegister(0x25, 0x33); // AEB AGC AEC Stable Operating Region Lower
+  writeToRegister(0x26, 0xE3); // VPT AGC AEC Fast Mode Operating Region
+  writeToRegister(0x9F, 0x78); // HRL High Reference Luminance
+  writeToRegister(0xA0, 0x68); // LRL Low Reference Luminance
+  writeToRegister(0xA1, 0x03); // DSPC3 DSP Control 3
+  writeToRegister(0xA6, 0xD8); // LPH Lower Limit of Probability for HRL
+  writeToRegister(0xA7, 0xD8); // UPL Upper Limit of Probability for LRL
+  writeToRegister(0xA8, 0xF0); // TPL Probability Threshold for LRL to control AEC/AGC speed
+  writeToRegister(0xA9, 0x90); // TPH  Probability Threshold for HRL to control AEC/AGC speed
+  writeToRegister(0xAA, 0x94); // NALG AEC algorithm selection, reserved
+  writeToRegister(0x13, 0xC5); // COM8 !! repeat AGC/AEC/AWB enables; probably disabling before changing settings and re-enabling
+  writeToRegister(0x30, 0x00); // HSYST HSYNC Rising Edge Delay
+  writeToRegister(0x31, 0x00); // HSYEN HSYNC Falling Edge Delay
+  writeToRegister(0x0E, 0x61); // COM5 RESERVED
+  writeToRegister(0x0F, 0x4B); // COM6 reset all timing when format changes; output of optical black row option
+  writeToRegister(0x16, 0x02); // RSVD RESERVED
+  //// writeToRegister(0x1E, 0x07);
+  writeToRegister(0x21, 0x02); // ADCCTR1 RESERVED
+  writeToRegister(0x22, 0x91); // ADCCTR2 RESERVED
+  writeToRegister(0x29, 0x07); // RSVD RESERVED 
+  writeToRegister(0x33, 0x0B); // CHLF Array Current Control RESERVED
+  writeToRegister(0x35, 0x0B); // RSVD RESERVed
+  writeToRegister(0x37, 0x1D); // ADC ADC Control RESERVED
+  writeToRegister(0x38, 0x71); // ACOM ADC and Analog Common Mode Control RESERVED
+  writeToRegister(0x39, 0x2A); // OFON ADC Offset Control RESERVED
+  writeToRegister(0x3C, 0x78); // COM12 HREF option when VSYNC low or always
+  writeToRegister(0x4D, 0x40); // DM_POS Dummy row position
+  writeToRegister(0x4E, 0x20); // RSVD RESERVED
+  writeToRegister(0x69, 0x00); // GFIX Fix Gain Control
+  writeToRegister(0x74, 0x10); // REG74 digital gain control select and manual controll
+  writeToRegister(0x8D, 0x4F); // RSVD RESERVED
+  writeToRegister(0x8E, 0x00); // RSVD RESERVED
+  writeToRegister(0x8F, 0x00); // RSVD RESERVED
+  writeToRegister(0x90, 0x00); // RSVD RESERVED
+  writeToRegister(0x91, 0x00); // RSVD RESERVED
+  writeToRegister(0x96, 0x00); // RSVD RESERVED
+  writeToRegister(0x9A, 0x00); // RSVD RESERVED
+  writeToRegister(0xB0, 0x84); // RSVD RESERVED
+  writeToRegister(0xB1, 0x0C); // ABLC1 ALBC enable/disable
+  writeToRegister(0xB2, 0x0E); // RSVD RESERVED
+  writeToRegister(0xB3, 0x82); // THL_ST ABLC Target
+  writeToRegister(0xB8, 0x0A); // RSVD RESERVED
 
-// AWBC AWB Control
-writeToRegister(0x43, 0x0A);
-writeToRegister(0x44, 0xF0);
-writeToRegister(0x45, 0x34);
-writeToRegister(0x46, 0x58);
-writeToRegister(0x47, 0x28);
-writeToRegister(0x48, 0x3A);
-writeToRegister(0x59, 0x88);
-writeToRegister(0x5A, 0x88);
-writeToRegister(0x5B, 0x44);
-writeToRegister(0x5C, 0x67);
-writeToRegister(0x5D, 0x49);
-writeToRegister(0x5E, 0x0E);
-writeToRegister(0x6C, 0x0A);
-writeToRegister(0x6D, 0x55);
-writeToRegister(0x6E, 0x11);
-writeToRegister(0x6F, 0x9E);
+  // AWBC AWB Control
+  writeToRegister(0x43, 0x0A);
+  writeToRegister(0x44, 0xF0);
+  writeToRegister(0x45, 0x34);
+  writeToRegister(0x46, 0x58);
+  writeToRegister(0x47, 0x28);
+  writeToRegister(0x48, 0x3A);
+  writeToRegister(0x59, 0x88);
+  writeToRegister(0x5A, 0x88);
+  writeToRegister(0x5B, 0x44);
+  writeToRegister(0x5C, 0x67);
+  writeToRegister(0x5D, 0x49);
+  writeToRegister(0x5E, 0x0E);
+  writeToRegister(0x6C, 0x0A);
+  writeToRegister(0x6D, 0x55);
+  writeToRegister(0x6E, 0x11);
+  writeToRegister(0x6F, 0x9E);
 
 
-writeToRegister(0x6A, 0x40); // GGAIN G Channel AWB Gain
-writeToRegister(0x01, 0x40); // BLUE AWB Blue channel gain
-writeToRegister(0x02, 0x60); // RED AWN REd channel gain
+  writeToRegister(0x6A, 0x40); // GGAIN G Channel AWB Gain
+  writeToRegister(0x01, 0x40); // BLUE AWB Blue channel gain
+  writeToRegister(0x02, 0x60); // RED AWN REd channel gain
 
-writeToRegister(0x13, 0xC7); // COM8 AGC/AEC/Banding/enable REPEAT
+  writeToRegister(0x13, 0xC7); // COM8 AGC/AEC/Banding/enable REPEAT
 
-// MTX Color Matrix Coefficients
-writeToRegister(0x4F, 0x80);
-writeToRegister(0x50, 0x80);
-writeToRegister(0x51, 0x00);
-writeToRegister(0x52, 0x22);
-writeToRegister(0x53, 0x5E);
-writeToRegister(0x54, 0x80);
-writeToRegister(0x58, 0x9E); // MTXS signs, auto contrast
+  // MTX Color Matrix Coefficients
+  writeToRegister(0x4F, 0x80);
+  writeToRegister(0x50, 0x80);
+  writeToRegister(0x51, 0x00);
+  writeToRegister(0x52, 0x22);
+  writeToRegister(0x53, 0x5E);
+  writeToRegister(0x54, 0x80);
+  writeToRegister(0x58, 0x9E); // MTXS signs, auto contrast
 
-writeToRegister(0x41, 0x08); // COM16 double color matrix, AWB gain enable, denoise, edge enhancement
-writeToRegister(0x3F, 0x00); // EDGE Edge Enhancement Adjustment
-writeToRegister(0x75, 0x05); // REG75 Edge enhancement lower limit
-writeToRegister(0x76, 0xE1); // REG76 Edge enhancement higher limit, black/white pixel correction
-writeToRegister(0x4C, 0x00); // DNSTH De-noise Strength
-writeToRegister(0x77, 0x01); // REG77 Offset, de-noise range control
-//// writeToRegister(0x3D, 0x48);
-writeToRegister(0x4B, 0x09); // REG4B, RESERVED, UV average unable
-writeToRegister(0xC9, 0x60); // SATCTR Saturation Control
-writeToRegister(0x56, 0x40); // CONTRAS Contrast Control
-writeToRegister(0x34, 0x11); // ARBLM Array Reference Control
-writeToRegister(0x3B, 0x12); // COM11 Night mode, auto 50/60Hz, exposure timing
-writeToRegister(0xA4, 0x82); // NT_CTRL auto frame adjustment dummy row
-writeToRegister(0x96, 0x00); // RSVD RESERVED
-writeToRegister(0x97, 0x30); // RSVD RESERVED
-writeToRegister(0x98, 0x20); // RSVD RESERVED
-writeToRegister(0x99, 0x30); // RSVD RESERVED
-writeToRegister(0x9A, 0x84); // RSVD RESERVED
-writeToRegister(0x9B, 0x29); // RSVD RESERVED
-writeToRegister(0x9C, 0x03); // RSVD RESERVED
-writeToRegister(0x9D, 0x4C); // BD50ST 50 Hz Banding Filter Value 
-writeToRegister(0x9E, 0x3F); // BD60ST ^0 Hz Banding Filter Value
-writeToRegister(0x78, 0x04); // RSVD RESERVED
-writeToRegister(0x79, 0x01); // RSVD RESERVED
-writeToRegister(0xC8, 0xF0); // RSVD RESERVED
-writeToRegister(0x79, 0x0F); // RSVD RESERVED
-writeToRegister(0xC8, 0x00); // RSVD RESERVED
-writeToRegister(0x79, 0x10); // RSVD RESERVED
-writeToRegister(0xC8, 0x7E); // RSVD RESERVED
-writeToRegister(0x79, 0x0A); // RSVD RESERVED
-writeToRegister(0xC8, 0x80); // RSVD RESERVED
-writeToRegister(0x79, 0x0B); // RSVD RESERVED
-writeToRegister(0xC8, 0x01); // RSVD RESERVED
-writeToRegister(0x79, 0x0C); // RSVD RESERVED
-writeToRegister(0xC8, 0x0F); // RSVD RESERVED
-writeToRegister(0x79, 0x0D); // RSVD RESERVED
-writeToRegister(0xC8, 0x20); // RSVD RESERVED
-writeToRegister(0x79, 0x09); // RSVD RESERVED
-writeToRegister(0xC8, 0x80); // RSVD RESERVED
-writeToRegister(0x79, 0x02); // RSVD RESERVED
-writeToRegister(0xC8, 0xC0); // RSVD RESERVED
-writeToRegister(0x79, 0x03); // RSVD RESERVED
-writeToRegister(0xC8, 0x40); // RSVD RESERVED
-writeToRegister(0x79, 0x05); // RSVD RESERVED
-writeToRegister(0xC8, 0x30); // RSVD RESERVED
-writeToRegister(0x79, 0x26); // RSVD RESERVED
-writeToRegister(0xFF, 0xFF);
+  writeToRegister(0x41, 0x08); // COM16 double color matrix, AWB gain enable, denoise, edge enhancement
+  writeToRegister(0x3F, 0x00); // EDGE Edge Enhancement Adjustment
+  writeToRegister(0x75, 0x05); // REG75 Edge enhancement lower limit
+  writeToRegister(0x76, 0xE1); // REG76 Edge enhancement higher limit, black/white pixel correction
+  writeToRegister(0x4C, 0x00); // DNSTH De-noise Strength
+  writeToRegister(0x77, 0x01); // REG77 Offset, de-noise range control
+  //// writeToRegister(0x3D, 0x48);
+  writeToRegister(0x4B, 0x09); // REG4B, RESERVED, UV average unable
+  writeToRegister(0xC9, 0x60); // SATCTR Saturation Control
+  writeToRegister(0x56, 0x40); // CONTRAS Contrast Control
+  writeToRegister(0x34, 0x11); // ARBLM Array Reference Control
+  writeToRegister(0x3B, 0x12); // COM11 Night mode, auto 50/60Hz, exposure timing
+  writeToRegister(0xA4, 0x82); // NT_CTRL auto frame adjustment dummy row
+  writeToRegister(0x96, 0x00); // RSVD RESERVED
+  writeToRegister(0x97, 0x30); // RSVD RESERVED
+  writeToRegister(0x98, 0x20); // RSVD RESERVED
+  writeToRegister(0x99, 0x30); // RSVD RESERVED
+  writeToRegister(0x9A, 0x84); // RSVD RESERVED
+  writeToRegister(0x9B, 0x29); // RSVD RESERVED
+  writeToRegister(0x9C, 0x03); // RSVD RESERVED
+  writeToRegister(0x9D, 0x4C); // BD50ST 50 Hz Banding Filter Value 
+  writeToRegister(0x9E, 0x3F); // BD60ST ^0 Hz Banding Filter Value
+  writeToRegister(0x78, 0x04); // RSVD RESERVED
+  writeToRegister(0x79, 0x01); // RSVD RESERVED
+  writeToRegister(0xC8, 0xF0); // RSVD RESERVED
+  writeToRegister(0x79, 0x0F); // RSVD RESERVED
+  writeToRegister(0xC8, 0x00); // RSVD RESERVED
+  writeToRegister(0x79, 0x10); // RSVD RESERVED
+  writeToRegister(0xC8, 0x7E); // RSVD RESERVED
+  writeToRegister(0x79, 0x0A); // RSVD RESERVED
+  writeToRegister(0xC8, 0x80); // RSVD RESERVED
+  writeToRegister(0x79, 0x0B); // RSVD RESERVED
+  writeToRegister(0xC8, 0x01); // RSVD RESERVED
+  writeToRegister(0x79, 0x0C); // RSVD RESERVED
+  writeToRegister(0xC8, 0x0F); // RSVD RESERVED
+  writeToRegister(0x79, 0x0D); // RSVD RESERVED
+  writeToRegister(0xC8, 0x20); // RSVD RESERVED
+  writeToRegister(0x79, 0x09); // RSVD RESERVED
+  writeToRegister(0xC8, 0x80); // RSVD RESERVED
+  writeToRegister(0x79, 0x02); // RSVD RESERVED
+  writeToRegister(0xC8, 0xC0); // RSVD RESERVED
+  writeToRegister(0x79, 0x03); // RSVD RESERVED
+  writeToRegister(0xC8, 0x40); // RSVD RESERVED
+  writeToRegister(0x79, 0x05); // RSVD RESERVED
+  writeToRegister(0xC8, 0x30); // RSVD RESERVED
+  writeToRegister(0x79, 0x26); // RSVD RESERVED
+  writeToRegister(0xFF, 0xFF);
 
-writeToRegister(0x15, 0x20); // COM10 *REF, *SYNC, PCLK polarities and settings
-writeToRegister(0x0C, 0x04); // COM3 output data MSB LSB swap, tristate options, scsale/DCW enable
-writeToRegister(0x3E, 0x19); // COM14 DCW and scaling PCLK, manual scaling enable, PCLK divider
-writeToRegister(0x72, 0x11); // SCALING_DCWCTR DCW Control
-writeToRegister(0x73, 0xF1); // SCALING PCLK_DIV
-writeToRegister(0x17, 0x16); // HSTART
-writeToRegister(0x18, 0x04); // HSTOP
-writeToRegister(0x32, 0xA4); // HREF
-writeToRegister(0x19, 0x02); // VSTRT
-writeToRegister(0x1A, 0x7A); // VSTOP
-writeToRegister(0x03, 0x0A); // VREF
-writeToRegister(0xFF, 0xFF); 
+  writeToRegister(0x15, 0x20); // COM10 *REF, *SYNC, PCLK polarities and settings
+  writeToRegister(0x0C, 0x04); // COM3 output data MSB LSB swap, tristate options, scsale/DCW enable
+  writeToRegister(0x3E, 0x19); // COM14 DCW and scaling PCLK, manual scaling enable, PCLK divider
+  writeToRegister(0x72, 0x11); // SCALING_DCWCTR DCW Control
+  writeToRegister(0x73, 0xF1); // SCALING PCLK_DIV
+  writeToRegister(0x17, 0x16); // HSTART
+  writeToRegister(0x18, 0x04); // HSTOP
+  writeToRegister(0x32, 0xA4); // HREF
+  writeToRegister(0x19, 0x02); // VSTRT
+  writeToRegister(0x1A, 0x7A); // VSTOP
+  writeToRegister(0x03, 0x0A); // VREF
+  writeToRegister(0xFF, 0xFF); 
 
-writeToRegister(0x12, 0x00); // COM7 output format - YUV?
-writeToRegister(0x8C, 0x00); // RSVD RESERVED
-writeToRegister(0x04, 0x00); // COM1 CCIR656, AEC low 2 LSB
-// writeToRegister(0x40, 0xC0); // COM15 data format output range, RGB555/565 option
-writeToRegister(0x14, 0x6A); // COM9 Automatic Gain Ceiling
+  writeToRegister(0x12, 0x00); // COM7 output format - YUV?
+  writeToRegister(0x8C, 0x00); // RSVD RESERVED
+  writeToRegister(0x04, 0x00); // COM1 CCIR656, AEC low 2 LSB
+  // writeToRegister(0x40, 0xC0); // COM15 data format output range, RGB555/565 option
+  writeToRegister(0x14, 0x6A); // COM9 Automatic Gain Ceiling
 
-// MTX Matrix Coefficients
-writeToRegister(0x4F, 0x80);
-writeToRegister(0x50, 0x80);
-writeToRegister(0x51, 0x00);
-writeToRegister(0x52, 0x22);
-writeToRegister(0x53, 0x5E);
-writeToRegister(0x54, 0x80);
+  // MTX Matrix Coefficients
+  writeToRegister(0x4F, 0x80);
+  writeToRegister(0x50, 0x80);
+  writeToRegister(0x51, 0x00);
+  writeToRegister(0x52, 0x22);
+  writeToRegister(0x53, 0x5E);
+  writeToRegister(0x54, 0x80);
 
-//// writeToRegister(0x3D, 0x40); // COM13 Gamma enable, UV saturation auto adjustment, UV swap
-writeToRegister(0xFF, 0xFF);
+  //// writeToRegister(0x3D, 0x40); // COM13 Gamma enable, UV saturation auto adjustment, UV swap
+  writeToRegister(0xFF, 0xFF);
 
-// writeToRegister(0x11, 0x1F);
-writeToRegister(0x0C, 0x08); // COM3 output data MSB/LSB swap, tri state options, scale/DCW enable
-writeToRegister(0x3E, 0x19); // COM14 DCW and scaling PCLK enable, manual scaling enable, PCLK divider
-writeToRegister(0x73, 0xF1); // SCALING_PCLK_DIV
-writeToRegister(0x12, 0x10); // COM7 SCCB register reset, output format
+  // writeToRegister(0x11, 0x1F);
+  writeToRegister(0x0C, 0x08); // COM3 output data MSB/LSB swap, tri state options, scale/DCW enable
+  writeToRegister(0x3E, 0x19); // COM14 DCW and scaling PCLK enable, manual scaling enable, PCLK divider
+  writeToRegister(0x73, 0xF1); // SCALING_PCLK_DIV
+  writeToRegister(0x12, 0x10); // COM7 SCCB register reset, output format
 
-delay(1000); // wait for registers to be set (because it is quite slow)
+  delay(1000); // wait for registers to be set (because it is quite slow)
 }
 
 uint8_t readFromRegister(int reg) {


### PR DESCRIPTION
- Copied register initialization to fix resolution and color from https://forum.arduino.cc/t/solved-problem-with-camera-module-ov7670/514763/6 ; original is probably from Linux drivers or the Arduino/Adafruit libraries
- Adjust image capture loop to run faster to eliminate screen tearing
- Add color correction matrix and adjust image YUV->RGB conversion to be correct for new register settings